### PR TITLE
Kw/develop

### DIFF
--- a/src/rich-log/MessageBuilder.cc
+++ b/src/rich-log/MessageBuilder.cc
@@ -13,12 +13,7 @@ MessageBuilder& MessageBuilder::operator()(const char* fmt, ...)
         {
             va_list args;
             va_start(args, fmt);
-
-#ifdef CC_OS_WINDOWS
-            std::vsprintf_s(formatted, 1024, fmt, args);
-#elif defined(CC_OS_LINUX)
             std::vsnprintf(formatted, 1024, fmt, args);
-#endif
             va_end(args);
         }
 

--- a/src/rich-log/MessageBuilder.cc
+++ b/src/rich-log/MessageBuilder.cc
@@ -17,6 +17,7 @@ void MessageBuilder::append_formatted(cc::string_view fmt, cc::span<cc::string c
             CC_ASSERT(arg_i < args.size());
             _msg += args[arg_i];
             ++arg_i;
+            ++i;
         }
         else
         {

--- a/src/rich-log/MessageBuilder.cc
+++ b/src/rich-log/MessageBuilder.cc
@@ -13,7 +13,12 @@ MessageBuilder& MessageBuilder::operator()(const char* fmt, ...)
         {
             va_list args;
             va_start(args, fmt);
-            ::vsprintf_s(formatted, 1024, fmt, args);
+
+#ifdef CC_OS_WINDOWS
+            std::vsprintf_s(formatted, 1024, fmt, args);
+#elif defined(CC_OS_LINUX)
+            std::vsnprintf(formatted, 1024, fmt, args);
+#endif
             va_end(args);
         }
 

--- a/src/rich-log/MessageBuilder.hh
+++ b/src/rich-log/MessageBuilder.hh
@@ -14,7 +14,7 @@ namespace rlog
 class MessageBuilder
 {
     // options
-private:
+public:
     void configure(prefix const& p) { _prefix = p.value; }
     void configure(sep const& s) { _sep = s.value; }
     void configure(no_sep_t) { _sep = ""; }

--- a/src/rich-log/MessageBuilder.hh
+++ b/src/rich-log/MessageBuilder.hh
@@ -16,18 +16,27 @@ class MessageBuilder
     // options
 private:
     void configure(prefix const& p) { _prefix = p.value; }
-    void configure(channel c) { _channel = c; }
     void configure(sep const& s) { _sep = s.value; }
     void configure(no_sep_t) { _sep = ""; }
+    void configure(use_err_stream_t) { _use_err_stream = true; }
+    void configure(location const& loc) { _location = &loc; }
+
+    void configure(info_t) { _prefix = "[info] "; }
+    void configure(warning_t)
+    {
+        _prefix = "[warn] ";
+        _use_err_stream = true;
+    }
+    void configure(error_t)
+    {
+        _prefix = "[error] ";
+        _use_err_stream = true;
+    }
+    void configure(debug_t) { _prefix = "[debug] "; }
 
     // formatted message
 public:
-    template <class... Args>
-    MessageBuilder& operator()(char const* fmt, Args&&... args)
-    {
-        // TODO
-        return *this;
-    }
+    MessageBuilder& operator()(char const* fmt, ...);
 
     // object log
 public:
@@ -41,7 +50,7 @@ public:
 
 public:
     template <class... Args>
-    MessageBuilder(rlog::location const& loc, Args&&... args) : _location(loc)
+    MessageBuilder(Args&&... args)
     {
         // configure message
         ((this->configure(cc::forward<Args>(args))), ...);
@@ -63,12 +72,13 @@ private:
     }
 
 private:
-    location const& _location;
-    channel _channel = info;
+    location const* _location = nullptr;
     char const* _prefix = "";
     char const* _sep = ", ";
 
     // TODO: some cleverly pooled buffer structure
     cc::string _msg;
+
+    bool _use_err_stream = false;
 };
 }

--- a/src/rich-log/MessageBuilder.hh
+++ b/src/rich-log/MessageBuilder.hh
@@ -18,7 +18,7 @@ private:
     void configure(prefix const& p) { _prefix = p.value; }
     void configure(sep const& s) { _sep = s.value; }
     void configure(no_sep_t) { _sep = ""; }
-    void configure(use_err_stream_t) { _use_err_stream = true; }
+    void configure(err_out_t) { _use_err_stream = true; }
     void configure(location const& loc) { _location = &loc; }
 
     void configure(info_t) { _prefix = "[info] "; }

--- a/src/rich-log/MessageBuilder.hh
+++ b/src/rich-log/MessageBuilder.hh
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <clean-core/forward.hh>
+#include <clean-core/span.hh>
 #include <clean-core/string.hh>
 
 #include <rich-log/fwd.hh>
@@ -36,7 +37,19 @@ public:
 
     // formatted message
 public:
-    MessageBuilder& operator()(char const* fmt, ...);
+    template <class... Args>
+    MessageBuilder& operator()(char const* fmt, Args const&... args)
+    {
+        if constexpr (sizeof...(Args) == 0)
+            append(fmt);
+        else
+        {
+            cc::string args_s[] = {rf::to_string(args)...};
+            append_formatted(fmt, args_s);
+        }
+
+        return *this;
+    }
 
     // object log
 public:
@@ -70,6 +83,8 @@ private:
             _msg += _sep;
         _msg += s;
     }
+
+    void append_formatted(cc::string_view fmt, cc::span<cc::string const> args);
 
 private:
     location const* _location = nullptr;

--- a/src/rich-log/fwd.hh
+++ b/src/rich-log/fwd.hh
@@ -4,4 +4,5 @@ namespace rlog
 {
 struct location;
 struct message;
+class MessageBuilder;
 }

--- a/src/rich-log/location.hh
+++ b/src/rich-log/location.hh
@@ -2,6 +2,8 @@
 
 namespace rlog
 {
+// NOTE: std::source_location can eventually replace this
+// which also removes the need for macros
 struct location
 {
     char const* function;

--- a/src/rich-log/options.hh
+++ b/src/rich-log/options.hh
@@ -6,14 +6,14 @@ namespace rlog
 {
 struct prefix
 {
-    explicit prefix(char const* v) : value(v) {}
+    explicit constexpr prefix(char const* v) : value(v) {}
 
     char const* value;
 };
 
 struct sep
 {
-    explicit sep(char const* v) : value(v) {}
+    explicit constexpr sep(char const* v) : value(v) {}
 
     char const* value;
 };
@@ -22,7 +22,7 @@ static constexpr struct no_sep_t
 {
 } no_sep;
 
-static constexpr struct use_err_stream_t
+static constexpr struct err_out_t
 {
 } err_out;
 

--- a/src/rich-log/options.hh
+++ b/src/rich-log/options.hh
@@ -4,15 +4,6 @@
 
 namespace rlog
 {
-// not enum class so that LOG(info) works
-enum channel
-{
-    info,
-    warning,
-    error,
-    debug
-};
-
 struct prefix
 {
     explicit prefix(char const* v) : value(v) {}
@@ -30,4 +21,23 @@ struct sep
 static constexpr struct no_sep_t
 {
 } no_sep;
+
+static constexpr struct use_err_stream_t
+{
+} err_out;
+
+// preconfigured channels
+static constexpr struct info_t
+{
+} info;
+static constexpr struct warning_t
+{
+} warning;
+static constexpr struct error_t
+{
+} error;
+static constexpr struct debug_t
+{
+} debug;
+
 }


### PR DESCRIPTION
- Add (temporary?) printf functionality to `operator()(char const*, ...)`
- Remove hardcoded channels, add preconfigured replacements for info, warning, etc.
- Remove `location` as a mandatory ctor argument