### PR TITLE
Fix win32 warnings about time_t, add verbose_no_color style

### DIFF
--- a/src/rich-log/logger.hh
+++ b/src/rich-log/logger.hh
@@ -25,6 +25,10 @@ enum class console_log_style
     // [message]
     // <the message being printed>\n
     message_only,
+
+    // like verbose, but without color. useful if running inside a terminal
+    // that performs poorly with color codes, like qt creators builtin terminal
+    verbose_no_color,
 };
 
 /// prints a formatted, colored prefix to the specified stream, of the form


### PR DESCRIPTION
- Fix win32 deprecation warnings about `std::localtime` / `localtime_s`
- Add `verbose_no_color` style
    Qt Creators builtin terminal performs poorly with a very large volume of colored messages and can hang/crash. It's not a large problem since "Run in Terminal" is now an option in run config, but the option is still good to have sometimes