### PR TITLE
log_style::verbose_with_location, DLL support

### DIFF
--- a/src/rich-log/MessageBuilder.cc
+++ b/src/rich-log/MessageBuilder.cc
@@ -61,7 +61,7 @@ MessageBuilder::~MessageBuilder()
     // TODO: send message to logger
     // DEBUG: console for now
     auto* const stream = _use_err_stream ? stderr : stdout;
-    print_prefix_to_stream(_severity, _domain, stream);
+    print_prefix_to_stream(_location, _severity, _domain, stream);
     std::fprintf(stream, "%s\n", _msg.c_str());
     std::fflush(stream);
 }

--- a/src/rich-log/MessageBuilder.cc
+++ b/src/rich-log/MessageBuilder.cc
@@ -49,6 +49,15 @@ void MessageBuilder::append_formatted(cc::string_view fmt, cc::span<cc::string c
             _msg += fmt[i];
         }
     }
+
+#ifdef CC_ENABLE_ASSERTIONS
+    if (arg_i != args.size())
+    {
+        std::fprintf(stderr, "[rich-log] provided %zu arguments for just %zu {} escape sequences\n    in log from %s:%d    (function %s)\n",
+                     args.size(), arg_i, this->_location.file, this->_location.line, this->_location.function);
+    }
+#endif
+
     CC_ASSERT(arg_i == args.size() && "less escape sequences than provided arguments");
 }
 

--- a/src/rich-log/MessageBuilder.hh
+++ b/src/rich-log/MessageBuilder.hh
@@ -5,16 +5,17 @@
 #include <clean-core/span.hh>
 #include <clean-core/string.hh>
 
+#include <reflector/to_string.hh>
+
+#include <rich-log/detail/api.hh>
 #include <rich-log/fwd.hh>
 #include <rich-log/location.hh>
 #include <rich-log/options.hh>
 
-#include <reflector/to_string.hh>
-
 namespace rlog
 {
 // TODO: get a big temporary buffer, write the message into the buffer, then copy into actual msg
-class MessageBuilder
+class RLOG_API MessageBuilder
 {
     // options
 public:

--- a/src/rich-log/detail/api.hh
+++ b/src/rich-log/detail/api.hh
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <clean-core/macros.hh>
+
+#ifdef CC_OS_WINDOWS
+
+#ifdef RLOG_BUILD_DLL
+
+#ifdef RLOG_DLL
+#define RLOG_API __declspec(dllexport)
+#else
+#define RLOG_API __declspec(dllimport)
+#endif
+
+#else
+#define RLOG_API
+#endif
+
+#else
+#define RLOG_API
+#endif

--- a/src/rich-log/detail/log_impl.hh
+++ b/src/rich-log/detail/log_impl.hh
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <clean-core/macros.hh>
-
 #include <rich-log/MessageBuilder.hh>
 #include <rich-log/location.hh>
 
-#define RICH_LOG_IMPL(_functor_) ::rlog::MessageBuilder(::rlog::location{CC_PRETTY_FUNC, __FILE__, __LINE__}, _functor_)
+#define RICH_LOG_IMPL(_functor_) ::rlog::MessageBuilder(RLOG_LOCATION(), _functor_)

--- a/src/rich-log/location.hh
+++ b/src/rich-log/location.hh
@@ -13,5 +13,6 @@ struct location
     int line;
 };
 
-#define RLOG_LOCATION() ::rlog::location{CC_PRETTY_FUNC, __FILE__, __LINE__}
+#define RLOG_LOCATION() \
+    ::rlog::location { CC_PRETTY_FUNC, __FILE__, __LINE__ }
 }

--- a/src/rich-log/location.hh
+++ b/src/rich-log/location.hh
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <clean-core/macros.hh>
+
 namespace rlog
 {
 // NOTE: std::source_location can eventually replace this
@@ -10,4 +12,6 @@ struct location
     char const* file;
     int line;
 };
+
+#define RLOG_LOCATION() ::rlog::location{CC_PRETTY_FUNC, __FILE__, __LINE__}
 }

--- a/src/rich-log/logger.cc
+++ b/src/rich-log/logger.cc
@@ -41,10 +41,15 @@ CC_FORCE_INLINE void write_timebuffer(char* timebuffer, size_t size, char const*
 }
 }
 
-int rlog::print_prefix_to_stream(rlog::severity severity, rlog::domain domain, std::FILE* stream)
+int rlog::print_prefix_to_stream(const location& location, rlog::severity severity, rlog::domain domain, std::FILE* stream)
 {
+    (void)location; // unused
+
     switch (g_log_style)
     {
+    case console_log_style::verbose_with_location:
+        std::fprintf(stream, "         %s:%d  (%s):\n", location.file, location.line, location.function);
+        // fall through
     case console_log_style::verbose:
     {
         // prepare timestamp

--- a/src/rich-log/logger.hh
+++ b/src/rich-log/logger.hh
@@ -5,6 +5,7 @@
 #include <clean-core/macros.hh>
 
 #include <rich-log/options.hh>
+#include <rich-log/location.hh>
 
 namespace rlog
 {
@@ -29,12 +30,15 @@ enum class console_log_style
     // like verbose, but without color. useful if running inside a terminal
     // that performs poorly with color codes, like qt creators builtin terminal
     verbose_no_color,
+
+    // like verbose, but also including filename:line for the log location
+    verbose_with_location
 };
 
 /// prints a formatted, colored prefix to the specified stream, of the form
 /// (or slightly different depending on log style)
 /// returns length of prefix
-int print_prefix_to_stream(severity severity, domain domain, std::FILE* stream = stdout);
+int print_prefix_to_stream(location const& location, severity severity, domain domain, std::FILE* stream = stdout);
 
 /// sets the name for the calling thread, as it appears in the log prefix, using printf syntax
 /// pass nullptr to un-set

--- a/src/rich-log/logger.hh
+++ b/src/rich-log/logger.hh
@@ -4,6 +4,7 @@
 
 #include <clean-core/macros.hh>
 
+#include <rich-log/detail/api.hh>
 #include <rich-log/location.hh>
 #include <rich-log/options.hh>
 
@@ -38,15 +39,15 @@ enum class console_log_style
 /// prints a formatted, colored prefix to the specified stream, of the form
 /// (or slightly different depending on log style)
 /// returns length of prefix
-int print_prefix_to_stream(location const& location, severity severity, domain domain, std::FILE* stream = stdout);
+RLOG_API int print_prefix_to_stream(location const& location, severity severity, domain domain, std::FILE* stream = stdout);
 
 /// sets the name for the calling thread, as it appears in the log prefix, using printf syntax
 /// pass nullptr to un-set
-void set_current_thread_name(char const* fmt, ...) CC_PRINTF_FUNC(1);
+RLOG_API void set_current_thread_name(char const* fmt, ...) CC_PRINTF_FUNC(1);
 
 /// changes the way print_to_console formats its output
-void set_console_log_style(console_log_style style);
+RLOG_API void set_console_log_style(console_log_style style);
 
 /// enables ANSI Escape sequences in Windows conhost.exe and cmd.exe
-bool enable_win32_colors();
+RLOG_API bool enable_win32_colors();
 }

--- a/src/rich-log/logger.hh
+++ b/src/rich-log/logger.hh
@@ -4,8 +4,8 @@
 
 #include <clean-core/macros.hh>
 
-#include <rich-log/options.hh>
 #include <rich-log/location.hh>
+#include <rich-log/options.hh>
 
 namespace rlog
 {


### PR DESCRIPTION
- Add `verbose_with_location` style which prepends file/line to each message
- Add `NX_BUILD_DLL` cmake option (via arcana_add_library) and matching `NX_API` macro for dllexports